### PR TITLE
Declare RestSharp dependency in nuspec

### DIFF
--- a/GitHubPushLib.nuspec
+++ b/GitHubPushLib.nuspec
@@ -13,5 +13,8 @@
     <releaseNotes>
       <![CDATA[For full release notes see https://github.com/pseudomuto/githubpushlib/releases]]>
     </releaseNotes>
+    <dependencies>
+      <dependency id="RestSharp" version="104.2.0" />
+    </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This pull request should fix #1. I haven't tested it because I don't own the nuget package.

The declared dependency matches [packages.config](https://github.com/pseudomuto/githubpushlib/blob/6af73455dcf2aa77627f88d810e49c30594039cd/src/GitHubPushLib/packages.config).

More information on declaring dependencies in nuspec can be found in the [nuget documentatoin](https://docs.nuget.org/create/nuspec-reference#specifying-dependencies).
